### PR TITLE
Encode stored Gemini API keys and add regression test

### DIFF
--- a/app/api/account/save-key/route.ts
+++ b/app/api/account/save-key/route.ts
@@ -52,8 +52,8 @@ export async function POST(request: NextRequest) {
     const { error } = await supabase.from("user_api_credentials").upsert({
       user_id: user.id,
       provider: "gemini",
-      encrypted_key: ciphertext,
-      nonce: nonce,
+      encrypted_key: ciphertext.toString("base64"),
+      nonce: nonce.toString("base64"),
     })
 
     if (error) {

--- a/lib/ai/gemini.test.ts
+++ b/lib/ai/gemini.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import crypto from 'crypto'
+
+// Simple in-memory store to simulate Supabase table
+const store: { record: any } = { record: null }
+
+vi.mock('@/lib/supabase/server', () => {
+  return {
+    createClient: () => ({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: store.record, error: null }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  }
+})
+
+import { getUserGeminiKey } from './gemini'
+
+function encryptSecret(plaintext: string): { ciphertext: Buffer; nonce: Buffer } {
+  const masterKey = process.env.APP_KMS_MASTER_KEY!
+  const key = Buffer.from(masterKey, 'base64')
+  const nonce = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, nonce)
+
+  let encrypted = cipher.update(plaintext, 'utf8')
+  encrypted = Buffer.concat([encrypted, cipher.final()])
+
+  const authTag = cipher.getAuthTag()
+  const ciphertext = Buffer.concat([encrypted, authTag])
+
+  return { ciphertext, nonce }
+}
+
+describe('Gemini key storage', () => {
+  it('encrypts, stores, retrieves, and decrypts the key', async () => {
+    const apiKey = 'AIzaSyDUMMYKEY'
+    process.env.APP_KMS_MASTER_KEY = crypto.randomBytes(32).toString('base64')
+
+    // Encrypt and store the key as the route handler would
+    const { ciphertext, nonce } = encryptSecret(apiKey)
+    store.record = {
+      encrypted_key: ciphertext.toString('base64'),
+      nonce: nonce.toString('base64'),
+    }
+
+    // Retrieve and decrypt via getUserGeminiKey
+    const result = await getUserGeminiKey('user-123')
+    expect(result).toBe(apiKey)
+  })
+})

--- a/lib/ai/gemini.ts
+++ b/lib/ai/gemini.ts
@@ -22,8 +22,8 @@ export async function getUserGeminiKey(userId: string): Promise<string> {
   }
 
   const key = Buffer.from(masterKey, "base64")
-  const nonce = Buffer.from(data.nonce)
-  const encryptedData = Buffer.from(data.encrypted_key)
+  const nonce = Buffer.from(data.nonce, "base64")
+  const encryptedData = Buffer.from(data.encrypted_key, "base64")
 
   // Split encrypted data and auth tag (last 16 bytes)
   const authTag = encryptedData.slice(-16)


### PR DESCRIPTION
## Summary
- Base64-encode ciphertext and nonce when saving user Gemini keys
- Decode stored Gemini key data from base64 before decryption
- Add regression test covering encrypt/store/retrieve/decrypt flow

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ecdee2ac8328961e9c6a282dfe95