### PR TITLE
Handle missing Supabase configuration gracefully

### DIFF
--- a/app/api/account/check-key/route.ts
+++ b/app/api/account/check-key/route.ts
@@ -1,7 +1,14 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@/lib/supabase/server"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 
 export async function GET(request: NextRequest) {
+  if (!isSupabaseConfigured) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
   try {
     const supabase = createClient()
     const {

--- a/app/api/account/delete-key/route.ts
+++ b/app/api/account/delete-key/route.ts
@@ -1,7 +1,14 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@/lib/supabase/server"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 
 export async function DELETE(request: NextRequest) {
+  if (!isSupabaseConfigured) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
   try {
     const supabase = createClient()
     const {

--- a/app/api/account/save-key/route.ts
+++ b/app/api/account/save-key/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@/lib/supabase/server"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import crypto from "crypto"
 
 const ALGO = "aes-256-gcm"
@@ -24,6 +24,13 @@ function encryptSecret(plaintext: string): { ciphertext: Buffer; nonce: Buffer }
 }
 
 export async function POST(request: NextRequest) {
+  if (!isSupabaseConfigured) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
   try {
     const supabase = createClient()
     const {

--- a/app/api/add-link/route.ts
+++ b/app/api/add-link/route.ts
@@ -1,11 +1,18 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@/lib/supabase/server"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { fetchPageMetadata } from "@/lib/scrape-meta"
 import { validateUrl } from "@/lib/validate-url"
 import { summarizeUrlWithGemini } from "@/lib/ai/gemini"
 import { upsertBookmarkEmbedding } from "@/lib/embeddings"
 
 export async function POST(request: NextRequest) {
+  if (!isSupabaseConfigured) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
   try {
     const supabase = createClient()
     const {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,8 +1,15 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@/lib/supabase/server"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { semanticSearch } from "@/lib/embeddings"
 
 export async function POST(request: NextRequest) {
+  if (!isSupabaseConfigured) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
   try {
     const supabase = createClient()
     const {

--- a/app/api/supabase-misconfig.test.ts
+++ b/app/api/supabase-misconfig.test.ts
@@ -1,0 +1,68 @@
+import { NextRequest } from "next/server"
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest"
+
+const originalUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const originalKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+describe("API routes with missing Supabase config", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = ""
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = ""
+    vi.resetModules()
+  })
+
+  afterAll(() => {
+    if (originalUrl === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    else process.env.NEXT_PUBLIC_SUPABASE_URL = originalUrl
+    if (originalKey === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    else process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalKey
+  })
+
+  it("add-link returns configuration error", async () => {
+    const { POST } = await import("./add-link/route")
+    const res = await POST(new NextRequest("http://localhost", { method: "POST" }))
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error).toMatch(/Supabase environment variables are not set/)
+  })
+
+  it("upload returns configuration error", async () => {
+    const { POST } = await import("./upload/route")
+    const res = await POST(new NextRequest("http://localhost", { method: "POST" }))
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error).toMatch(/Supabase environment variables are not set/)
+  })
+
+  it("chat returns configuration error", async () => {
+    const { POST } = await import("./chat/route")
+    const res = await POST(new NextRequest("http://localhost", { method: "POST" }))
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error).toMatch(/Supabase environment variables are not set/)
+  })
+
+  it("check-key returns configuration error", async () => {
+    const { GET } = await import("./account/check-key/route")
+    const res = await GET(new NextRequest("http://localhost"))
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error).toMatch(/Supabase environment variables are not set/)
+  })
+
+  it("save-key returns configuration error", async () => {
+    const { POST } = await import("./account/save-key/route")
+    const res = await POST(new NextRequest("http://localhost", { method: "POST" }))
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error).toMatch(/Supabase environment variables are not set/)
+  })
+
+  it("delete-key returns configuration error", async () => {
+    const { DELETE } = await import("./account/delete-key/route")
+    const res = await DELETE(new NextRequest("http://localhost", { method: "DELETE" }))
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error).toMatch(/Supabase environment variables are not set/)
+  })
+})

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@/lib/supabase/server"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { parseNetscapeBookmarks } from "@/lib/parse-bookmarks"
 import { fetchPageMetadata } from "@/lib/scrape-meta"
 import { validateUrl } from "@/lib/validate-url"
@@ -7,6 +7,13 @@ import { summarizeUrlWithGemini } from "@/lib/ai/gemini"
 import { upsertBookmarkEmbedding } from "@/lib/embeddings"
 
 export async function POST(request: NextRequest) {
+  if (!isSupabaseConfigured) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
   try {
     const supabase = createClient()
     const {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config"
+import path from "path"
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add configuration guard to each API route when Supabase env vars missing
- test routes without Supabase config to ensure graceful failures
- configure Vitest alias for `@` imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6efedddf883289e9be1f9c579034e