### PR TITLE
refactor: make Supabase config check runtime

### DIFF
--- a/app/api/account/check-key/route.ts
+++ b/app/api/account/check-key/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 
 export async function GET(request: NextRequest) {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     return NextResponse.json(
       { error: "Supabase environment variables are not set" },
       { status: 500 },

--- a/app/api/account/delete-key/route.ts
+++ b/app/api/account/delete-key/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 
 export async function DELETE(request: NextRequest) {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     return NextResponse.json(
       { error: "Supabase environment variables are not set" },
       { status: 500 },

--- a/app/api/account/save-key/route.ts
+++ b/app/api/account/save-key/route.ts
@@ -24,7 +24,7 @@ function encryptSecret(plaintext: string): { ciphertext: Buffer; nonce: Buffer }
 }
 
 export async function POST(request: NextRequest) {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     return NextResponse.json(
       { error: "Supabase environment variables are not set" },
       { status: 500 },

--- a/app/api/add-link/route.ts
+++ b/app/api/add-link/route.ts
@@ -6,7 +6,7 @@ import { summarizeUrlWithGemini } from "@/lib/ai/gemini"
 import { upsertBookmarkEmbedding } from "@/lib/embeddings"
 
 export async function POST(request: NextRequest) {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     return NextResponse.json(
       { error: "Supabase environment variables are not set" },
       { status: 500 },

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -3,7 +3,7 @@ import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { semanticSearch } from "@/lib/embeddings"
 
 export async function POST(request: NextRequest) {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     return NextResponse.json(
       { error: "Supabase environment variables are not set" },
       { status: 500 },

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -7,7 +7,7 @@ import { summarizeUrlWithGemini } from "@/lib/ai/gemini"
 import { upsertBookmarkEmbedding } from "@/lib/embeddings"
 
 export async function POST(request: NextRequest) {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     return NextResponse.json(
       { error: "Supabase environment variables are not set" },
       { status: 500 },

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation"
 import LoginForm from "@/components/login-form"
 
 export default async function LoginPage() {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#000080]">
         <h1 className="text-2xl font-bold mb-4 text-white">Connect Supabase to get started</h1>

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation"
 import SignUpForm from "@/components/signup-form"
 
 export default async function SignUpPage() {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#000080]">
         <h1 className="text-2xl font-bold mb-4 text-white">Connect Supabase to get started</h1>

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,14 +1,17 @@
 import { createClient as createSupabaseClient } from "@supabase/supabase-js"
 
 // Check if Supabase environment variables are available
-export const isSupabaseConfigured =
-  typeof process.env.NEXT_PUBLIC_SUPABASE_URL === "string" &&
-  process.env.NEXT_PUBLIC_SUPABASE_URL.length > 0 &&
-  typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === "string" &&
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.length > 0
+export function isSupabaseConfigured() {
+  return (
+    typeof process.env.NEXT_PUBLIC_SUPABASE_URL === "string" &&
+    process.env.NEXT_PUBLIC_SUPABASE_URL.length > 0 &&
+    typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === "string" &&
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.length > 0
+  )
+}
 
 export function createClient() {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     console.warn("Supabase environment variables are not set. Using dummy client.")
     return {
       auth: {

--- a/lib/supabase/isSupabaseConfigured.test.ts
+++ b/lib/supabase/isSupabaseConfigured.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterAll } from "vitest"
+import { isSupabaseConfigured } from "@/lib/supabase/server"
+
+const originalUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const originalKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+afterAll(() => {
+  if (originalUrl === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_URL
+  else process.env.NEXT_PUBLIC_SUPABASE_URL = originalUrl
+  if (originalKey === undefined) delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  else process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalKey
+})
+
+describe("isSupabaseConfigured", () => {
+  it("reflects runtime environment variable changes", () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = ""
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = ""
+    expect(isSupabaseConfigured()).toBe(false)
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com"
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon"
+    expect(isSupabaseConfigured()).toBe(true)
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = ""
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = ""
+    expect(isSupabaseConfigured()).toBe(false)
+  })
+})

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -3,14 +3,17 @@ import { cookies } from "next/headers"
 import { cache } from "react"
 
 // Check if Supabase environment variables are available
-export const isSupabaseConfigured =
-  typeof process.env.NEXT_PUBLIC_SUPABASE_URL === "string" &&
-  process.env.NEXT_PUBLIC_SUPABASE_URL.length > 0 &&
-  typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === "string" &&
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.length > 0
+export function isSupabaseConfigured() {
+  return (
+    typeof process.env.NEXT_PUBLIC_SUPABASE_URL === "string" &&
+    process.env.NEXT_PUBLIC_SUPABASE_URL.length > 0 &&
+    typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === "string" &&
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.length > 0
+  )
+}
 
 export const createClient = cache(() => {
-  if (!isSupabaseConfigured) {
+  if (!isSupabaseConfigured()) {
     console.warn("Supabase environment variables are not set. Using dummy client.")
     return {
       auth: {


### PR DESCRIPTION
## Summary
- replace static `isSupabaseConfigured` with a function that reads env vars at call time
- update all pages and API routes to invoke `isSupabaseConfigured()`
- add test verifying env changes are reflected

## Testing
- `pnpm test`
- `pnpm lint` *(fails: asks how to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68a71f233e0083288708a4bea91baa1d