### PR TITLE
feat: enhance server supabase dummy client

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -19,7 +19,20 @@ export const createClient = cache(() => {
       auth: {
         getUser: () => Promise.resolve({ data: { user: null }, error: null }),
         getSession: () => Promise.resolve({ data: { session: null }, error: null }),
+        signInWithPassword: () =>
+          Promise.resolve({ data: null, error: { message: "Supabase not configured" } }),
+        signUp: () =>
+          Promise.resolve({ data: null, error: { message: "Supabase not configured" } }),
+        signOut: () =>
+          Promise.resolve({ data: null, error: { message: "Supabase not configured" } }),
       },
+      from: () => ({
+        select: () => Promise.resolve({ data: [], error: null }),
+        insert: () => Promise.resolve({ data: null, error: null }),
+        update: () => Promise.resolve({ data: null, error: null }),
+        delete: () => Promise.resolve({ data: null, error: null }),
+      }),
+      rpc: () => Promise.resolve({ data: null, error: null }),
     } as any
   }
 


### PR DESCRIPTION
## Summary
- extend server supabase dummy client with auth stubs for sign-in, sign-up, and sign-out when configuration is missing
- add no-op data access and RPC methods to server-side dummy client

## Testing
- `pnpm test`
- `pnpm lint` *(fails: next lint prompts for configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68a7901865208328b0e59f93b97ee5c1