### PR TITLE
refactor: simplify login success handling

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -6,8 +6,6 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Loader2 } from "lucide-react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { useEffect } from "react"
 import { signIn } from "@/lib/actions"
 
 function SubmitButton() {
@@ -32,14 +30,7 @@ function SubmitButton() {
 }
 
 export default function LoginForm() {
-  const router = useRouter()
   const [state, formAction] = useActionState(signIn, null)
-
-  useEffect(() => {
-    if (state?.success) {
-      router.push("/")
-    }
-  }, [state, router])
 
   return (
     <div className="w-full max-w-md space-y-8">


### PR DESCRIPTION
## Summary
- remove unused success `useEffect` from login form and rely on server redirect

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a79a2f6a1083289df71cc070aced89