### PR TITLE
Persist Supabase session via server-side cookies

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -49,12 +49,16 @@ export const createClient = cache(() => {
             return cookie?.value || null
           },
           setItem: (key: string, value: string) => {
-            // Server-side can't set cookies directly
-            // This will be handled by the client-side auth flow
+            cookieStore.set(key, value, {
+              path: "/",
+              maxAge: 60 * 60 * 24 * 365,
+              sameSite: "lax",
+              secure: process.env.NODE_ENV === "production",
+              httpOnly: true,
+            })
           },
           removeItem: (key: string) => {
-            // Server-side can't remove cookies directly
-            // This will be handled by the client-side auth flow
+            cookieStore.delete(key)
           },
         },
       },


### PR DESCRIPTION
## Summary
- enable Supabase auth session persistence on server by writing/removing cookies

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a8243125a483289dc2836b03812937