### PR TITLE
Add bookmarks and categories API routes

### DIFF
--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
+
+export async function GET(request: NextRequest) {
+  if (!isSupabaseConfigured()) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
+  try {
+    const supabase = createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const category = searchParams.get("category")
+
+    let query = supabase
+      .from("bookmarks")
+      .select(
+        "id, title, url, description, favicon_url, category_id, folder_path",
+      )
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+
+    if (category) {
+      const categoryId = Number(category)
+      if (!Number.isNaN(categoryId)) {
+        query = query.eq("category_id", categoryId)
+      } else {
+        query = query.eq("folder_path", category)
+      }
+    }
+
+    const { data, error } = await query
+
+    if (error) {
+      console.error("Failed to fetch bookmarks:", error)
+      return NextResponse.json(
+        { error: "Failed to fetch bookmarks" },
+        { status: 500 },
+      )
+    }
+
+    return NextResponse.json({ bookmarks: data || [] })
+  } catch (error) {
+    console.error("Bookmarks GET error:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch bookmarks" },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,68 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
+
+interface CategoryNode {
+  id: number
+  name: string
+  path: string
+  parent_id: number | null
+  children: CategoryNode[]
+}
+
+export async function GET(_request: NextRequest) {
+  if (!isSupabaseConfigured()) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
+  try {
+    const supabase = createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { data, error } = await supabase
+      .from("categories")
+      .select("id, name, parent_id, path")
+      .eq("user_id", user.id)
+      .order("path", { ascending: true })
+
+    if (error) {
+      console.error("Failed to fetch categories:", error)
+      return NextResponse.json(
+        { error: "Failed to fetch categories" },
+        { status: 500 },
+      )
+    }
+
+    const map = new Map<number, CategoryNode>()
+    const roots: CategoryNode[] = []
+
+    for (const cat of data || []) {
+      map.set(cat.id, { ...cat, children: [] })
+    }
+
+    for (const cat of data || []) {
+      const node = map.get(cat.id)!
+      if (cat.parent_id && map.has(cat.parent_id)) {
+        map.get(cat.parent_id)!.children.push(node)
+      } else {
+        roots.push(node)
+      }
+    }
+
+    return NextResponse.json({ categories: roots })
+  } catch (error) {
+    console.error("Categories GET error:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch categories" },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add bookmarks API GET handler with optional category filtering
- add categories API GET handler returning a nested tree

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a879be5c4883289da4a30ae3df59df