### PR TITLE
Add bookmark update and deletion endpoints

### DIFF
--- a/app/api/bookmarks/[id]/route.ts
+++ b/app/api/bookmarks/[id]/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  if (!isSupabaseConfigured()) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
+  try {
+    const supabase = createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const id = Number(params.id)
+    if (Number.isNaN(id)) {
+      return NextResponse.json({ error: "Invalid bookmark id" }, { status: 400 })
+    }
+
+    const body = await request.json()
+    const update: { category_id?: number | null; folder_path?: string | null } = {}
+    if ("category_id" in body) {
+      update.category_id = body.category_id
+    } else if ("categoryId" in body) {
+      update.category_id = body.categoryId
+    }
+    if ("folder_path" in body) {
+      update.folder_path = body.folder_path
+    } else if ("folderPath" in body) {
+      update.folder_path = body.folderPath
+    }
+
+    const { error } = await supabase
+      .from("bookmarks")
+      .update(update)
+      .eq("id", id)
+      .eq("user_id", user.id)
+
+    if (error) {
+      console.error("Failed to update bookmark:", error)
+      return NextResponse.json(
+        { error: "Failed to update bookmark" },
+        { status: 500 },
+      )
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Bookmarks PATCH error:", error)
+    return NextResponse.json(
+      { error: "Failed to update bookmark" },
+      { status: 500 },
+    )
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  if (!isSupabaseConfigured()) {
+    return NextResponse.json(
+      { error: "Supabase environment variables are not set" },
+      { status: 500 },
+    )
+  }
+
+  try {
+    const supabase = createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const id = Number(params.id)
+    if (Number.isNaN(id)) {
+      return NextResponse.json({ error: "Invalid bookmark id" }, { status: 400 })
+    }
+
+    const { error } = await supabase
+      .from("bookmarks")
+      .delete()
+      .eq("id", id)
+      .eq("user_id", user.id)
+
+    if (error) {
+      console.error("Failed to delete bookmark:", error)
+      return NextResponse.json(
+        { error: "Failed to delete bookmark" },
+        { status: 500 },
+      )
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Bookmarks DELETE error:", error)
+    return NextResponse.json(
+      { error: "Failed to delete bookmark" },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add PATCH and DELETE API handlers for bookmarks
- expose move and delete actions in BookmarkList

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a89145a8d483288167cc47211441ba