### PR TITLE
Track import counts and surface upload results

### DIFF
--- a/components/upload-dropzone.tsx
+++ b/components/upload-dropzone.tsx
@@ -39,10 +39,13 @@ export default function UploadDropzone({ onUploadComplete }: UploadDropzoneProps
       const result = await response.json()
 
       if (response.ok) {
-        alert("Bookmarks imported successfully!")
-        onUploadComplete?.()
+        alert(`Imported ${result.imported} bookmarks. Failed: ${result.failed}.`)
+        if (result.imported > 0) {
+          onUploadComplete?.()
+        }
       } else {
-        alert(`Import failed: ${result.error}`)
+        const message = result.errors?.join("\n") || result.error
+        alert(`Import failed. Imported: ${result.imported}, Failed: ${result.failed}.\n${message}`)
       }
     } catch (error) {
       console.error("Upload error:", error)


### PR DESCRIPTION
## Summary
- track number of bookmarks imported and failed, collecting error messages during processing
- API returns imported/failed counts and errors, sending error status when nothing imported
- Upload UI shows import results and only fires completion callback on successful import

## Testing
- `pnpm test`
- `pnpm lint` *(fails: requires ESLint configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68a8cbc060288328ab00ba526e89cd59