### PR TITLE
Handle fetch errors before refreshing bookmark list

### DIFF
--- a/components/bookmark-list.tsx
+++ b/components/bookmark-list.tsx
@@ -71,16 +71,26 @@ export default function BookmarkList({ refreshTrigger = 0 }: BookmarkListProps) 
   }, [fetchData, refreshTrigger])
 
   const handleMove = async (id: number, categoryId: number | null) => {
-    await fetch(`/api/bookmarks/${id}`, {
+    const response = await fetch(`/api/bookmarks/${id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ category_id: categoryId }),
     })
+    if (!response.ok) {
+      const error = await response.json()
+      alert(error.error || error.message || "Failed to move bookmark")
+      return
+    }
     fetchData()
   }
 
   const handleDelete = async (id: number) => {
-    await fetch(`/api/bookmarks/${id}`, { method: "DELETE" })
+    const response = await fetch(`/api/bookmarks/${id}`, { method: "DELETE" })
+    if (!response.ok) {
+      const error = await response.json()
+      alert(error.error || error.message || "Failed to delete bookmark")
+      return
+    }
     fetchData()
   }
 


### PR DESCRIPTION
## Summary
- add error handling to bookmark move and delete actions
- avoid refreshing bookmarks when operations fail

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a90986b7e883288fb6ff8032a8a330