### PR TITLE
refactor: simplify server client factory

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,6 +1,5 @@
 import { createClient as createSupabaseClient } from "@supabase/supabase-js"
 import { cookies } from "next/headers"
-import { cache } from "react"
 
 // Check if Supabase environment variables are available
 export function isSupabaseConfigured() {
@@ -12,7 +11,7 @@ export function isSupabaseConfigured() {
   )
 }
 
-export const createClient = cache(() => {
+export function createClient() {
   if (!isSupabaseConfigured()) {
     console.warn("Supabase environment variables are not set. Using dummy client.")
     return {
@@ -66,4 +65,4 @@ export const createClient = cache(() => {
   )
 
   return supabase
-})
+}


### PR DESCRIPTION
## Summary
- remove React `cache` wrapper and import in Supabase server client
- expose `createClient` as plain function that calls `cookies()` per invocation

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8bf4092483289803f91097f9e198