### PR TITLE
Expose thrown signIn errors

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -42,7 +42,7 @@ export async function signIn(prevState: any, formData: FormData) {
       }
       return { error: error.message }
     }
-    return { error: "An unexpected error occurred. Please try again." }
+    return { error: error instanceof Error ? error.message : String(error) }
   }
 
   redirect("/")


### PR DESCRIPTION
## Summary
- surface original thrown value in signIn catch block

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc7cb1ee48328ae8b61205a789916