### PR TITLE
fix: Resolve Netlify build error by setting Node.js runtime

### DIFF
--- a/app/api/account/check-key/route.ts
+++ b/app/api/account/check-key/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs"
+
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 

--- a/app/api/account/delete-key/route.ts
+++ b/app/api/account/delete-key/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs"
+
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 

--- a/app/api/account/save-key/route.ts
+++ b/app/api/account/save-key/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs"
+
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import crypto from "crypto"

--- a/app/api/add-link/route.ts
+++ b/app/api/add-link/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs"
+
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { fetchPageMetadata } from "@/lib/scrape-meta"

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs"
+
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs"
+
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs"
+
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { semanticSearch } from "@/lib/embeddings"

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs"
+
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient, isSupabaseConfigured } from "@/lib/supabase/server"
 import { parseNetscapeBookmarks } from "@/lib/parse-bookmarks"


### PR DESCRIPTION
This commit fixes a persistent build failure on Netlify that was causing the deployment to fail. The error was `TypeError: The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received undefined`.

This error was caused by the use of Node.js-specific APIs and libraries in the API routes, which are not compatible with the default serverless environment on Netlify.

The fix is to explicitly set the runtime for all API routes to `nodejs` by adding `export const runtime = 'nodejs'` to each route handler file. This ensures that the routes are built and executed in a full Node.js environment, which is compatible with all the libraries used in the project.